### PR TITLE
Fix weekly timezone error

### DIFF
--- a/generate_weekly.py
+++ b/generate_weekly.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from collections import Counter
 import re
 
@@ -9,7 +9,7 @@ OUTPUT_FILE = "trending_weekly.md"
 DAYS = 7
 
 def get_last_n_days_files(n):
-    today = datetime.now(datetime.UTC)
+    today = datetime.now(timezone.utc)
     files = []
     if os.path.exists(HIST_DIR):
         for i in range(n):


### PR DESCRIPTION
## Summary
- fix timezone usage in weekly generator

## Testing
- `python -m py_compile fetch_trending.py generate_weekly.py generate_monthly.py`


------
https://chatgpt.com/codex/tasks/task_e_683f5ab71a08832aa4a1b6f4db22c383